### PR TITLE
removed pycrypto 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ bs4
 fleep
 Pillow
 requests
-pycrypto
 netifaces
 prettytable
 libarchive-c


### PR DESCRIPTION
due to it being outdated and manually installing a alternative before